### PR TITLE
*: ui.Start doesn't need IDs, plus fix readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,24 +39,25 @@ can be sent to a file.
 ```go
 package main
 
-import "github.com/amonks/run"
+import "github.com/amonks/run/pkg/run"
 
 func main() {
-	tasks, err := run.Load(".")
-	if err != nil {
-		log.Fatal(err)
-	}
+	tasks, _ := run.Load(".")
+	r, _ := run.RunTask(".", tasks, "dev")
+	ui := run.NewTUI(r)
 
-	r := run.RunTask(tasks, "dev")
+	ctx := context.Background()
+	uiReady := make(chan struct{})
 
-	ui := run.NewTUI()
-	ui.Start(os.Stdin, os.Stdout, r.IDs())
-	run.Start(ui)
+	go ui.Start(ctx, uiReady, os.Stdin, os.Stdout)
+	<- uiReady
+
+	r.Start(ctx, ui) // blocks until done
 }
 ```
 
 Run can be used and extended programmatically through its Go API. See [the
-godoc][godoc]
+godoc][godoc].
 
 [godoc]: https://amonks.github.io/run
 

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -86,12 +86,12 @@ func main() {
 	case "tui":
 		ui = run.NewTUI(r)
 	case "printer":
-		ui = run.NewPrinter()
+		ui = run.NewPrinter(r)
 	case "":
 		if !term.IsTerminal(int(os.Stdout.Fd())) {
-			ui = run.NewPrinter()
+			ui = run.NewPrinter(r)
 		} else if r.Type() == run.RunTypeShort {
-			ui = run.NewPrinter()
+			ui = run.NewPrinter(r)
 		} else {
 			ui = run.NewTUI(r)
 		}
@@ -108,7 +108,7 @@ func main() {
 
 	go func() {
 		defer wg.Done()
-		err := ui.Start(ctx, uiReady, os.Stdin, os.Stdout, r.IDs())
+		err := ui.Start(ctx, uiReady, os.Stdin, os.Stdout)
 		if err != nil && err != context.Canceled {
 			fmt.Println("Error running ui:", err)
 		}

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,44 +121,17 @@ which isn&#39;t too much more complex.
 		
 			<p>Code:</p>
 			<pre class="code">
-tasks, err := run.Load(&#34;.&#34;)
-if err != nil {
-    log.Fatal(err)
-}
-
-r, err := run.RunTask(&#34;.&#34;, tasks, &#34;dev&#34;)
-if err != nil {
-    log.Fatal(err)
-}
-
-ctx, cancel := context.WithCancel(context.Background())
-
+tasks, _ := run.Load(&#34;.&#34;)
+r, _ := run.RunTask(&#34;.&#34;, tasks, &#34;dev&#34;)
 ui := run.NewTUI(r)
 
-var wg sync.WaitGroup
-ready := make(chan struct{})
+ctx := context.Background()
+uiReady := make(chan struct{})
 
-wg.Add(1)
-go func() {
-    defer wg.Done()
-    if err := ui.Start(ctx, ready, os.Stdin, os.Stdout, r.IDs()); err != nil {
-        log.Fatal(err)
-    }
-    cancel()
-}()
+go ui.Start(ctx, uiReady, os.Stdin, os.Stdout)
+&lt;-uiReady
 
-&lt;-ready
-
-wg.Add(1)
-go func() {
-    defer wg.Done()
-    if err := r.Start(ctx, ui); err != nil {
-        log.Fatal(err)
-    }
-    cancel()
-}()
-
-wg.Wait()
+r.Start(ctx, ui) <span class="comment">// blocks until done</span>
 </pre>
 			
 		
@@ -354,7 +327,7 @@ func Example_bringYourOwnUI() {
 				<dd><a href="#UI">type UI</a></dd>
 				
 					
-					<dd>&nbsp; &nbsp; <a href="#NewPrinter">func NewPrinter() UI</a></dd>
+					<dd>&nbsp; &nbsp; <a href="#NewPrinter">func NewPrinter(run *Run) UI</a></dd>
 				
 					
 					<dd>&nbsp; &nbsp; <a href="#NewTUI">func NewTUI(run *Run) UI</a></dd>
@@ -914,7 +887,7 @@ stopped. Since UIs implement <a href="#MultiWriter">MultiWriter</a>, they can be
 <p>The functions <a href="#NewTUI">NewTUI</a> and <a href="#NewPrinter">NewPrinter</a> produce implementors of UI.
 
 			<pre>type UI interface {
-    Start(ctx <a href="https://pkg.go.dev/pkg/context/">context</a>.<a href="https://pkg.go.dev/pkg/context/#Context">Context</a>, ready chan&lt;- struct{}, stdin <a href="https://pkg.go.dev/pkg/io/">io</a>.<a href="https://pkg.go.dev/pkg/io/#Reader">Reader</a>, stdout <a href="https://pkg.go.dev/pkg/io/">io</a>.<a href="https://pkg.go.dev/pkg/io/#Writer">Writer</a>, ids []<a href="https://pkg.go.dev/pkg/builtin/#string">string</a>) <a href="https://pkg.go.dev/pkg/builtin/#error">error</a>
+    Start(ctx <a href="https://pkg.go.dev/pkg/context/">context</a>.<a href="https://pkg.go.dev/pkg/context/#Context">Context</a>, ready chan&lt;- struct{}, stdin <a href="https://pkg.go.dev/pkg/io/">io</a>.<a href="https://pkg.go.dev/pkg/io/#Reader">Reader</a>, stdout <a href="https://pkg.go.dev/pkg/io/">io</a>.<a href="https://pkg.go.dev/pkg/io/#Writer">Writer</a>) <a href="https://pkg.go.dev/pkg/builtin/#error">error</a>
     Writer(id <a href="https://pkg.go.dev/pkg/builtin/#string">string</a>) <a href="https://pkg.go.dev/pkg/io/">io</a>.<a href="https://pkg.go.dev/pkg/io/#Writer">Writer</a>
 }</pre>
 
@@ -933,7 +906,7 @@ stopped. Since UIs implement <a href="#MultiWriter">MultiWriter</a>, they can be
 					
 					
 				</h3>
-				<pre>func NewPrinter() <a href="#UI">UI</a></pre>
+				<pre>func NewPrinter(run *<a href="#Run">Run</a>) <a href="#UI">UI</a></pre>
 				<p>NewPrinter produces a non-interactive UI for displaying interleaved
 multiplexed streams. The UI prints interleaved output from all of the
 streams to its Stdout. The output is suitable for piping to a file.

--- a/pkg/run/example_test.go
+++ b/pkg/run/example_test.go
@@ -2,9 +2,7 @@ package run_test
 
 import (
 	"context"
-	"log"
 	"os"
-	"sync"
 
 	"github.com/amonks/run/pkg/run"
 )
@@ -13,42 +11,15 @@ import (
 // the run CLI tool. See cmd/run for the source of the -real- run CLI,
 // which isn't too much more complex.
 func Example() {
-	tasks, err := run.Load(".")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	r, err := run.RunTask(".", tasks, "dev")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
+	tasks, _ := run.Load(".")
+	r, _ := run.RunTask(".", tasks, "dev")
 	ui := run.NewTUI(r)
 
-	var wg sync.WaitGroup
-	ready := make(chan struct{})
+	ctx := context.Background()
+	uiReady := make(chan struct{})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := ui.Start(ctx, ready, os.Stdin, os.Stdout, r.IDs()); err != nil {
-			log.Fatal(err)
-		}
-		cancel()
-	}()
+	go ui.Start(ctx, uiReady, os.Stdin, os.Stdout)
+	<- uiReady
 
-	<-ready
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := r.Start(ctx, ui); err != nil {
-			log.Fatal(err)
-		}
-		cancel()
-	}()
-
-	wg.Wait()
+	r.Start(ctx, ui) // blocks until done
 }

--- a/pkg/run/printer.go
+++ b/pkg/run/printer.go
@@ -9,12 +9,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-func newPrinter() UI {
-	return &printer{mu: newMutex("printer")}
+func newPrinter(run *Run) UI {
+	return &printer{mu: newMutex("printer"), run: run}
 }
 
 type printer struct {
 	mu        *mutex
+	run       *Run
 	stdout    io.Writer
 	keyLength int
 	lastKey   string
@@ -39,10 +40,10 @@ func (w printerWriter) Write(bs []byte) (int, error) {
 	return len(bs), nil
 }
 
-func (p *printer) Start(ctx context.Context, ready chan<- struct{}, _ io.Reader, stdout io.Writer, ids []string) error {
+func (p *printer) Start(ctx context.Context, ready chan<- struct{}, _ io.Reader, stdout io.Writer) error {
 	p.stdout = stdout
 	p.keyLength = 0
-	for _, id := range ids {
+	for _, id := range p.run.IDs() {
 		if len(id) > p.keyLength {
 			p.keyLength = len(id)
 		}

--- a/pkg/run/tui.go
+++ b/pkg/run/tui.go
@@ -82,11 +82,11 @@ func (w tuiWriter) Write(bs []byte) (int, error) {
 // *tui implements UI
 var _ UI = &tui{}
 
-func (a *tui) Start(ctx context.Context, ready chan<- struct{}, stdin io.Reader, stdout io.Writer, ids []string) error {
+func (a *tui) Start(ctx context.Context, ready chan<- struct{}, stdin io.Reader, stdout io.Writer) error {
 	program := tea.NewProgram(
 		&tuiModel{
 			run:    a.run,
-			ids:    append([]string{"interleaved"}, ids...),
+			ids:    append([]string{"interleaved"}, a.run.IDs()...),
 			onInit: func() { ready <- struct{}{} },
 		},
 		tea.WithAltScreen(),
@@ -96,9 +96,9 @@ func (a *tui) Start(ctx context.Context, ready chan<- struct{}, stdin io.Reader,
 
 	interleavedWriter := a.Writer("interleaved")
 	a.mu.printf("will make printer")
-	p := NewPrinter()
+	p := NewPrinter(a.run)
 	a.mu.printf("made printer")
-	go p.Start(ctx, nil, nil, interleavedWriter, ids)
+	go p.Start(ctx, nil, nil, interleavedWriter)
 	a.mu.printf("started")
 	a.interleaved = p
 

--- a/pkg/run/ui.go
+++ b/pkg/run/ui.go
@@ -21,7 +21,7 @@ func NewTUI(run *Run) UI { return newTUI(run) }
 // The UI can be passed into [Run.Start] to display a run's execution.
 //
 // The UI is safe to access concurrently from multiple goroutines.
-func NewPrinter() UI { return newPrinter() }
+func NewPrinter(run *Run) UI { return newPrinter(run) }
 
 // A UI is essentially a multiplexed [io.Writer] that can be started and
 // stopped. Since UIs implement [MultiWriter], they can be passed into
@@ -29,7 +29,7 @@ func NewPrinter() UI { return newPrinter() }
 //
 // The functions [NewTUI] and [NewPrinter] produce implementors of UI.
 type UI interface {
-	Start(ctx context.Context, ready chan<- struct{}, stdin io.Reader, stdout io.Writer, ids []string) error
+	Start(ctx context.Context, ready chan<- struct{}, stdin io.Reader, stdout io.Writer) error
 	Writer(id string) io.Writer
 }
 


### PR DESCRIPTION
I started out just trying to make the README example compile, and then I noticed that the UIs take IDs effectively twice: once by passing Run to their constructor, then again as an argument to Start.

If we're passing the whole-ass Run, we don't need to also pass IDs.

Anyway, I also simplified example_test until it was short enough to paste into the README, and pasted it into the README. This will make it much easier to ensure it's up-to-date.

We remove the parameter from Start.