### PR TITLE
run_task: use the output writer

### DIFF
--- a/pkg/run/run_task.go
+++ b/pkg/run/run_task.go
@@ -195,7 +195,7 @@ func (r *Run) Start(ctx context.Context, out MultiWriter) error {
 	printf := func(id string, style lipgloss.Style, f string, args ...interface{}) {
 		w := writers.get(id)
 		s := fmt.Sprintf(f, args...)
-		w.Write([]byte(style.Render(s)+ "\n"))
+		w.Write([]byte(style.Render(s) + "\n"))
 	}
 
 	// Start all the file watchers. Do this before starting tasks so that
@@ -255,7 +255,8 @@ func (r *Run) Start(ctx context.Context, out MultiWriter) error {
 
 		exits.set(id, make(chan exit))
 		r.taskStatus.set(id, TaskStatusRunning)
-		err := t.Start(ctx, out.Writer(id))
+		w := writers.get(id)
+		err := t.Start(ctx, w)
 		cancels.del(id)
 
 		select {


### PR DESCRIPTION
looks like some changes were causing a regression on the thing we fixed yesterday

before change:
![image](https://github.com/amonks/run/assets/4583705/eb5c8aa3-e8bf-48f1-9885-74ae5c8046e2)


after change:
![image](https://github.com/amonks/run/assets/4583705/280a9045-d093-483b-9a08-2fda2990a611)
