### PR TITLE
feat: configurable taskfile name

### DIFF
--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	fUI   = flag.String("ui", "", "Force a particular ui. Legal values are 'tui' and 'printer'.")
-	fDir  = flag.String("dir", ".", "Look for a root taskfile in the given directory.")
-	fList = flag.Bool("list", false, "Display the task list and exit. If run is invoked with both -list and a task ID, that task's dependencies are displayed.")
+	fUI       = flag.String("ui", "", "Force a particular ui. Legal values are 'tui' and 'printer'.")
+	fDir      = flag.String("dir", ".", "Look for a root taskfile in the given directory.")
+	fTaskfile = flag.String("taskfile", "tasks.toml", "Look for a taskfile by this name.")
+	fList     = flag.Bool("list", false, "Display the task list and exit. If run is invoked with both -list and a task ID, that task's dependencies are displayed.")
 
 	fVersion      = flag.Bool("version", false, "Display the version and exit.")
 	fHelp         = flag.Bool("help", false, "Display the help text and exit.")
@@ -54,7 +55,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	allTasks, err := run.Load(*fDir)
+	allTasks, err := run.Load(*fDir, *fTaskfile)
 	if err != nil {
 		fmt.Println("Error loading tasks:")
 		fmt.Println(err)

--- a/pkg/run/taskfile.go
+++ b/pkg/run/taskfile.go
@@ -12,12 +12,12 @@ import (
 
 // Load loads a task file from the specified directory, producing a set of
 // Tasks.
-func Load(cwd string) (Tasks, error) {
+func Load(cwd string, filename string) (Tasks, error) {
 	allTasks := map[string]taskfileTask{}
 
 	seenDirs := map[string]struct{}{}
-	var ingestTaskMap func(dir string) error
-	ingestTaskMap = func(dir string) error {
+	var ingestTaskMap func(dir, name string) error
+	ingestTaskMap = func(dir, name string) error {
 		if _, ok := seenDirs[dir]; ok {
 			return nil
 		}
@@ -28,7 +28,7 @@ func Load(cwd string) (Tasks, error) {
 			relativeDir = "."
 		}
 
-		theseTasks, err := load(cwd, dir)
+		theseTasks, err := load(cwd, dir, name)
 		if err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ func Load(cwd string) (Tasks, error) {
 
 			p = strings.TrimPrefix(p, relativeDir+string(os.PathSeparator))
 			p = filepath.Join(dir, p)
-			if err := ingestTaskMap(p); err != nil {
+			if err := ingestTaskMap(p, "tasks.toml"); err != nil {
 				return err
 			}
 		}
@@ -68,7 +68,7 @@ func Load(cwd string) (Tasks, error) {
 		return nil
 	}
 
-	if err := ingestTaskMap("."); err != nil {
+	if err := ingestTaskMap(".", filename); err != nil {
 		return nil, err
 	}
 
@@ -101,8 +101,8 @@ func Load(cwd string) (Tasks, error) {
 	return tf, nil
 }
 
-func load(cwd, dir string) (map[string]taskfileTask, error) {
-	f, err := os.ReadFile(filepath.Join(cwd, dir, "tasks.toml"))
+func load(cwd, dir, name string) (map[string]taskfileTask, error) {
+	f, err := os.ReadFile(filepath.Join(cwd, dir, name))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/run/taskfile_test.go
+++ b/pkg/run/taskfile_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTaskfileNestingWithDir(t *testing.T) {
-	ts, err := Load("./testdata/very-nested")
+	ts, err := Load("./testdata/very-nested", "tasks.toml")
 	assert.NoError(t, err)
 
 	testNesting(t, ts)
@@ -25,7 +25,7 @@ func TestTaskfileNestingWithParentDir(t *testing.T) {
 	os.Chdir("testdata/very-nested/child")
 	defer os.Chdir("../../..")
 
-	ts, err := Load("..")
+	ts, err := Load("..", "tasks.toml")
 	assert.NoError(t, err)
 
 	testNesting(t, ts)
@@ -42,7 +42,7 @@ func TestTaskfileNestingWithDot(t *testing.T) {
 	os.Chdir("testdata/very-nested")
 	defer os.Chdir("../..")
 
-	ts, err := Load(".")
+	ts, err := Load(".", "tasks.toml")
 	assert.NoError(t, err)
 
 	testNesting(t, ts)


### PR DESCRIPTION
In another project, I need to have two different taskfiles: one that's parsed locally, and another that's parsed in Docker. The local file can't be used in CI because it references subtasks from a folder which is dockerignored.

It feels kind of gross that you can override the name of the root taskfile but not sub taskfiles. Maybe there's a more flexible mechanism for this that I'm not thinking of.