### PR TITLE
fix: short cmdless tasks exit when dependencies are done

### DIFF
--- a/pkg/run/script_task.go
+++ b/pkg/run/script_task.go
@@ -65,7 +65,12 @@ func (t *scriptTask) Start(ctx context.Context, stdout io.Writer) error {
 	t.stdout = stdout
 
 	if !t.hasScript() {
-		<-ctx.Done()
+		// If this is a "long" task, we want to keep running until the
+		// run is killed. If this is a "short" task with no script, we
+		// should consider it done as soon as its dependencies are.
+		if t.Metadata().Type == "long" {
+			<-ctx.Done()
+		}
 		return nil
 	}
 

--- a/pkg/run/testdata/snapshots/group-short-long/out.log
+++ b/pkg/run/testdata/snapshots/group-short-long/out.log
@@ -1,0 +1,17 @@
+ok
+
+  watcher  starting
+           .
+           invalidating {subtask}
+
+  subtask  starting
+           hello
+           exit ok
+           invalidating {test}
+
+     test  starting
+           exit ok
+
+      run  done
+
+  watcher  canceled; stopping

--- a/pkg/run/testdata/snapshots/group-short-long/tasks.toml
+++ b/pkg/run/testdata/snapshots/group-short-long/tasks.toml
@@ -1,0 +1,15 @@
+[[task]]
+  id="test"
+  type="short"
+  dependencies=["subtask"]
+
+[[task]]
+  id="subtask"
+  type="short"
+  cmd="echo hello"
+  dependencies=["watcher"]
+
+[[task]]
+  id="watcher"
+  type="long"
+  cmd="while true ; do echo . ; sleep 1 ; done"


### PR DESCRIPTION
Before the last update (which allowed cmd-less tasks to be short), all cmd-less tasks were considered "long", and were kept alive until the run was canceled by something else.

The last update mistakenly preserved this keepalive behavior, even for "short" cmd-less tasks.