### PR TITLE
ecs - one line install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ individual tasks.
 
 # Installation
 
-Run is a single binary, which you can download from from the [releases
-page][releases].
+Run is a single binary, which you can download from from the [releases page][releases].
 
-Alternately, if you already use go, you can install Run with the go command
-line tool:
+## Install Script (MacOS, Linux)
+
+Download and install the latest version of `run` to the current working directory.
+ 
+```sh
+curl -L https://raw.githubusercontent.com/amonks/run/main/install.sh | sh
+```
+
+## Install with Go
+
+If you already use go, you can install Run with the go command line tool:
 
     $ go install github.com/amonks/run/cmd/run@latest
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Run is a single binary, which you can download from from the [releases page][rel
 
 ## Install Script (MacOS, Linux)
 
-Download and install the latest version of `run` to the current working directory.
+This install command will download the latest version of run to your current directory.
  
 ```sh
 curl -L https://raw.githubusercontent.com/amonks/run/main/install.sh | sh

--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,10 @@ set -e          # Exit immediately if a command fails
 set -o pipefail # Fail a pipeline if any command fails
 
 main() {
-    # Check for the existence of a file named "run" in the current directory.
-    if [ -f run ]; then
-        echo "Error: run is already installed in the current directory."
-        echo "To reinstall, remove the existing run binary and execute this script again."
+    # Check for the existence of anything named "run" in the current directory.
+    if [ -e run ]; then
+        echo "An item named 'run' exists in the current directory."
+        echo "Refusing to overwrite it. Please move or delete it and try again."
         exit 1
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# This script downloads the latest release of run from GitHub and installs it 
+# to the current directory.
+
+# Print an error message before exiting.
+trap 'echo "Error: $0:$LINENO -- installation failed"' ERR 
+
+set -e          # Exit immediately if a command fails
+set -o pipefail # Fail a pipeline if any command fails
+
+main() {
+    # Check for the existence of a file named "run" in the current directory.
+    if [ -f run ]; then
+        echo "Error: run is already installed in the current directory."
+        echo "To reinstall, remove the existing run binary and execute this script again."
+        exit 1
+    fi
+
+    OS=$(uname)
+    ARCH=$(arch)
+
+    # Determine the download URL for the current operating system and architecture.
+    TARGET_ASSET="run_${OS}_${ARCH}.tar.gz"
+    DOWNLOAD_URL="https://github.com/amonks/run/releases/latest/download/${TARGET_ASSET}"
+
+    # Attempt the download and extraction. Suppress error output from curl and tar.
+    curl -fsSL $DOWNLOAD_URL 2>/dev/null | tar -xz run 2>/dev/null
+
+    echo "Downloaded Run (latest $OS $ARCH) to ./run"
+    ./run -version
+    echo "Launch it from here or move it to a directory in your PATH."
+}
+
+main "$1"


### PR DESCRIPTION
This script downloads the latest release of the `run` binary from GitHub and extracts it to the working directory.

Addresses #94 

- wrap in main() function and call main at the end of the file
- pulled `OS` and `ARCH` into variables, reuse them in success output
- output the version information on successful installation
- update readme

![install](https://github.com/amonks/run/assets/1425775/6eda0f04-b5a7-42f2-a71b-1f1cfee03afd)
