### PR TITLE
build: add freebsd GOOS target

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,10 @@ builds:
     goos:
       - linux
       - darwin
+      - freebsd
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - format: tar.gz
@@ -20,19 +24,20 @@ archives:
       - CONTRIBUTORS.*
       - CREDITS.*
       - docs/*
+
+    # NOTE
+    # ensure the OS and Arch values match (uname -m) and (uname -a).
     name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
+      run_
+      {{- if eq .Os "freebsd" }}FreeBSD
+      {{- else }}{{- title .Os }}
+      {{- end }}_
       {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+      {{- else }}{{- .Arch }}
+      {{- end }}
 
 checksum:
   name_template: "checksums.txt"
-
-snapshot:
-  name_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# This script downloads the latest release of run from GitHub and installs it 
+# This script downloads the latest release of run from GitHub and installs it
 # to the current directory.
 
 # Print an error message before exiting.
-trap 'echo "Error: $0:$LINENO -- installation failed"' ERR 
+trap 'echo "Error: $0:$LINENO -- installation failed"' ERR
 
 set -e          # Exit immediately if a command fails
 set -o pipefail # Fail a pipeline if any command fails
@@ -17,8 +17,8 @@ main() {
         exit 1
     fi
 
-    OS=$(uname)
-    ARCH=$(arch)
+    OS=$(uname -s)
+    ARCH=$(uname -m)
 
     # Determine the download URL for the current operating system and architecture.
     TARGET_ASSET="run_${OS}_${ARCH}.tar.gz"


### PR DESCRIPTION
closes https://github.com/amonks/run/issues/102

I learned a couple things while doing this:
- Intel Macs report "i386" when you run `arch`, even though they run
  amd64; `uname -m` reports the correct value — this is an artifact of
  the PPC-to-Intel transition, ca. 2008. This [makes me a liar][liar].
  (I updated install.sh accordingly).
- Officially in Go, "amd64" is called "amd64_v1".
- Maybe goreleaser is good, actually.

[liar]: https://github.com/amonks/run/pull/101/files#r1545855399