### PR TITLE
chore: update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/amonks/run
 
-go 1.22
-
-toolchain go1.22.1
+go 1.22.2
 
 replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 


### PR DESCRIPTION
1.22.1 failed a govulncheck:
https://github.com/amonks/run/actions/runs/8556402647/job/23446116951?pr=119#step:4:102